### PR TITLE
Fix bc

### DIFF
--- a/src/domain.h
+++ b/src/domain.h
@@ -66,62 +66,64 @@ void adjust_bc(double *q, double *psi) {
   // adjust indices and ranks for first and last processor 
   if (rank == 0) { // south
     id_so = 0;
-    rank_m1 = n_ranks-1;
+    rank_m1 = rank_crit;
   }
-  if (rank == n_ranks-1){ // north
+  if (rank == rank_crit){ // north
     id_no = Ny;
     rank_p1 = 0;
   }
-  
-  for(int k = 0; k<nl; k++){
-    if (rank%2 == 0){ // even inner ranks (send first)
-      
-      //send/receive psi
-      MPI_Status  status;
-          
-      // send
-      MPI_Send(&psi[idx(0,id_so,k)], Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD); // South
-      MPI_Send(&psi[idx(0,id_no,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD); // North
-          
-      // receive
-      MPI_Recv(&psi[idx(0,0,k)],  Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD, &status); //South
-      MPI_Recv(&psi[idx(0,Ny,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD, &status); //North
-          
-      // send/receive q
-      MPI_Status  status2;
-          
-      // send
-      MPI_Send(&q[idx(0,id_so,k)], Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD); // South 
-      MPI_Send(&q[idx(0,id_no,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD); // North
-          
-      // receive
-      MPI_Recv(&q[idx(0,0,k)],  Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD, &status2); //South
-      MPI_Recv(&q[idx(0,Ny,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD, &status2); // North
+
+  if (rank <= rank_crit){
+    for(int k = 0; k<nl; k++){
+      if (rank%2 == 0){ // even inner ranks (send first)
         
-    } else { // odd inner ranks (receive first)
+        //send/receive psi
+        MPI_Status  status;
+            
+        // send
+        MPI_Send(&psi[idx(0,id_so,k)], Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD); // South
+        MPI_Send(&psi[idx(0,id_no,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD); // North
+            
+        // receive
+        MPI_Recv(&psi[idx(0,Ny,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD, &status); //North
+        MPI_Recv(&psi[idx(0,0,k)],  Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD, &status); //South
+            
+        // send/receive q
+        MPI_Status  status2;
+            
+        // send
+        MPI_Send(&q[idx(0,id_so,k)], Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD); // South 
+        MPI_Send(&q[idx(0,id_no,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD); // North
+            
+        // receive
+        MPI_Recv(&q[idx(0,Ny,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD, &status2); // North
+        MPI_Recv(&q[idx(0,0,k)],  Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD, &status2); //South
           
-      //send/receive psi
-      MPI_Status  status;
+      } else { // odd inner ranks (receive first)
+            
+        //send/receive psi
+        MPI_Status  status;
+            
+        // receive
+        MPI_Recv(&psi[idx(0,Ny,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD, &status); //North
+        MPI_Recv(&psi[idx(0,0,k)],  Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD, &status); //South
+            
+        // send
+        MPI_Send(&psi[idx(0,id_so,k)], Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD); // South
+        MPI_Send(&psi[idx(0,id_no,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD); // North
+            
+        // send/receive q
+        MPI_Status  status2;
+            
+        // receive
+        MPI_Recv(&q[idx(0,Ny,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD, &status2); // North
+        MPI_Recv(&q[idx(0,0,k)],  Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD, &status2); //South
+            
+        // send
+        MPI_Send(&q[idx(0,id_so,k)], Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD); // South
+        MPI_Send(&q[idx(0,id_no,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD); // North
           
-      // receive
-      MPI_Recv(&psi[idx(0,0,k)],  Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD, &status); //South
-      MPI_Recv(&psi[idx(0,Ny,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD, &status); //North
-          
-      // send
-      MPI_Send(&psi[idx(0,id_so,k)], Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD); // South
-      MPI_Send(&psi[idx(0,id_no,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD); // North
-          
-      // send/receive q
-      MPI_Status  status2;
-          
-      // receive
-      MPI_Recv(&q[idx(0,0,k)],  Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD, &status2); //South
-      MPI_Recv(&q[idx(0,Ny,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD, &status2); // North
-          
-      // send
-      MPI_Send(&q[idx(0,id_so,k)], Nxp1, MPI_DOUBLE, rank_m1, 0, MPI_COMM_WORLD); // South
-      MPI_Send(&q[idx(0,id_no,k)], Nxp1, MPI_DOUBLE, rank_p1, 0, MPI_COMM_WORLD); // North
-        
+      }
     }
   }
 #endif
@@ -141,7 +143,7 @@ void adjust_bc(double *q, double *psi) {
 
       // North
 #ifdef _MPI
-    if (rank == n_ranks-1)
+    if (rank == rank_crit)
 #endif
       for(int i = 0; i <Nxp1; i++){
         int j = Ny;

--- a/src/domain.h
+++ b/src/domain.h
@@ -19,7 +19,7 @@ void init_domain() {
   for(int i = 0; i <Nxp1; i++)
     X[i] = i*Delta;
   for(int j = 0; j<Nyp1; j++)
-    Y[j] = (j + J0 - 1)*Delta;
+    Y[j] = (j + J0)*Delta;
 
 
   // Coordinates in spectral space
@@ -30,7 +30,7 @@ void init_domain() {
     L[i] = pi*(i)/Lx;
 
   for(int j = 1; j<Ny; j++)
-    K[j] = pi*(j + J0 - 1)/Ly;
+    K[j] = pi*(j + J0)/Ly;
 
 }
 

--- a/src/domain.h
+++ b/src/domain.h
@@ -30,7 +30,7 @@ void init_domain() {
     L[i] = pi*(i)/Lx;
 
   for(int j = 1; j<Ny; j++)
-    K[j] = pi*(j + J0)/Ly;
+    K[j] = pi*(j + J0 - 1)/Ly;
 
 }
 

--- a/src/domain.h
+++ b/src/domain.h
@@ -4,6 +4,25 @@
    
 */
 
+
+// global size
+int NX, NY;
+int NXp1, NYp1;
+int NXm1, NYm1;
+
+// local size
+int Nx, Ny;
+int Nxm1, Nym1;
+int Nxp1, Nyp1;
+
+// Physical grid
+double *X;
+double *Y;
+
+// Fourier Coefficients
+double *K;
+double *L;
+
 // grid indices
 #define idx(i,j,k) (k)*Nxp1*Nyp1 + (j)*Nxp1 + (i)
 

--- a/src/elliptic.h
+++ b/src/elliptic.h
@@ -41,16 +41,13 @@ void init_elliptic(){
 
 #ifdef _MPI
 
-  long int fft_dims[2];
-  fft_dims[0] = Nym1;
-  fft_dims[1] = Nxm1;
+  int blocksize;
+  blocksize = ceil((double)Nym1/n_ranks);
+  rank_crit = ceil((double)Nym1/blocksize)-1;
   
-  int block0 = (int) NY/n_ranks;
-
   /* get local data size and allocate */
-  alloc_local = fftw_mpi_local_size_many(2, &fft_dims[0],1,block0,MPI_COMM_WORLD,
-                                         &local_n0, &local_0_start);
-
+  alloc_local = fftw_mpi_local_size_2d(Nym1, Nxm1, MPI_COMM_WORLD,
+                                       &local_n0, &local_0_start);
   wrk1 = fftw_alloc_real(alloc_local);
 
   /* create plan for out-of-place */
@@ -63,7 +60,7 @@ void init_elliptic(){
   Ny = local_n0 + 1;
   Nym1 = local_n0;
   Nyp1 = local_n0 + 2;
-  
+
 #else
 
   J0 = 0;

--- a/src/elliptic.h
+++ b/src/elliptic.h
@@ -40,11 +40,17 @@ void init_elliptic(){
   NYp1 = NY + 1;
 
 #ifdef _MPI
+
+  long int fft_dims[2];
+  fft_dims[0] = Nym1;
+  fft_dims[1] = Nxm1;
   
+  int block0 = (int) NY/n_ranks;
+
   /* get local data size and allocate */
-  alloc_local = fftw_mpi_local_size_2d(Nym1, Nxm1, MPI_COMM_WORLD,
-                                       &local_n0, &local_0_start);
-   
+  alloc_local = fftw_mpi_local_size_many(2, &fft_dims[0],1,block0,MPI_COMM_WORLD,
+                                         &local_n0, &local_0_start);
+
   wrk1 = fftw_alloc_real(alloc_local);
 
   /* create plan for out-of-place */

--- a/src/elliptic.h
+++ b/src/elliptic.h
@@ -59,14 +59,14 @@ void init_elliptic(){
   transfo_inverse = fftw_mpi_plan_r2r_2d(Nym1, Nxm1, wrk1, wrk1, MPI_COMM_WORLD,
                                          FFTW_RODFT00, FFTW_RODFT00, FFTW_EXHAUSTIVE|FFTW_MPI_TRANSPOSED_IN);
   
-  J0 = local_0_start + 1; // member the fourier grid starts at the index 1 of the real space grid
+  J0 = local_0_start;
   Ny = local_n0 + 1;
   Nym1 = local_n0;
   Nyp1 = local_n0 + 2;
   
 #else
 
-  J0 = 1;
+  J0 = 0;
   alloc_local = Nxm1*Nym1;
 
   wrk1 = fftw_alloc_real(alloc_local);

--- a/src/elliptic.h
+++ b/src/elliptic.h
@@ -22,11 +22,11 @@ ptrdiff_t alloc_local, local_n0, local_0_start;
 
 void init_elliptic(){
   
-  
   /**
      Prepare local indices
   */
 
+  // idealy this should be in init_domain
   Nx = NX;
   Ny = NY;
 
@@ -36,24 +36,27 @@ void init_elliptic(){
   Nxp1 = Nx + 1;
   Nyp1 = Ny + 1;
 
+  NXm1 = NX - 1;
+  NYm1 = NY - 1;
+
   NXp1 = NX + 1;
   NYp1 = NY + 1;
 
 #ifdef _MPI
 
   int blocksize;
-  blocksize = ceil((double)Nym1/n_ranks);
-  rank_crit = ceil((double)Nym1/blocksize)-1;
+  blocksize = ceil((double)NYm1/n_ranks);
+  rank_crit = ceil((double)NYm1/blocksize)-1;
   
   /* get local data size and allocate */
-  alloc_local = fftw_mpi_local_size_2d(Nym1, Nxm1, MPI_COMM_WORLD,
+  alloc_local = fftw_mpi_local_size_2d(NYm1, NXm1, MPI_COMM_WORLD,
                                        &local_n0, &local_0_start);
   wrk1 = fftw_alloc_real(alloc_local);
 
   /* create plan for out-of-place */
-  transfo_direct = fftw_mpi_plan_r2r_2d(Nym1, Nxm1, wrk1, wrk1, MPI_COMM_WORLD,
+  transfo_direct = fftw_mpi_plan_r2r_2d(NYm1, NXm1, wrk1, wrk1, MPI_COMM_WORLD,
                                         FFTW_RODFT00, FFTW_RODFT00, FFTW_EXHAUSTIVE|FFTW_MPI_TRANSPOSED_OUT);
-  transfo_inverse = fftw_mpi_plan_r2r_2d(Nym1, Nxm1, wrk1, wrk1, MPI_COMM_WORLD,
+  transfo_inverse = fftw_mpi_plan_r2r_2d(NYm1, NXm1, wrk1, wrk1, MPI_COMM_WORLD,
                                          FFTW_RODFT00, FFTW_RODFT00, FFTW_EXHAUSTIVE|FFTW_MPI_TRANSPOSED_IN);
   
   J0 = local_0_start;

--- a/src/mpi_utils.h
+++ b/src/mpi_utils.h
@@ -5,6 +5,7 @@
 
 int rank;
 int n_ranks;
+int rank_crit; // last rank to obtain a meaningful data chunk
 
 int J0; 
 

--- a/src/netcdf_io.h
+++ b/src/netcdf_io.h
@@ -226,7 +226,7 @@ void write_nc() {
     for (int k = 0; k < nl; k++) {
       for (int j = 0; j < Nyp1; j++) {
         for (int i = 0; i < Nxp1; i++) {
-          field[NYp1*NXp1*k + NXp1*(j+J0-1) + i] = data_loc[idx(i,j,k)];
+          field[NYp1*NXp1*k + NXp1*(j + J0) + i] = data_loc[idx(i,j,k)];
         }
       }
     }
@@ -312,7 +312,7 @@ void read_nc(char* file_in){
       for (int k = 0; k < nl; k++) {
         for (int j = 0; j < Nyp1; j++) {
           for (int i = 0; i < Nxp1; i++) {
-            q[idx(i,j,k)] = field[NYp1*NXp1*k + NXp1*(j+J0-1) + i];
+            q[idx(i,j,k)] = field[NYp1*NXp1*k + NXp1*(j + J0) + i];
           }
         }
       } // end k loop

--- a/src/qg.c
+++ b/src/qg.c
@@ -33,6 +33,7 @@
 #ifdef _MPI
   #include <mpi.h>
   #include <fftw3-mpi.h>
+  int rank_crit; // last rank to obtain a meaningful data chunk
 #endif
 
 #define sq(x) ((x)*(x)) // alias for square function

--- a/src/qg.c
+++ b/src/qg.c
@@ -33,7 +33,6 @@
 #ifdef _MPI
   #include <mpi.h>
   #include <fftw3-mpi.h>
-  int rank_crit; // last rank to obtain a meaningful data chunk
 #endif
 
 #define sq(x) ((x)*(x)) // alias for square function
@@ -47,20 +46,6 @@ double pi = 3.141592653589793;
 // field variables
 double *psi;
 double *q;
-double *X;
-double *Y;
-
-// Fourier Coefficients
-double *K;
-double *L;
-
-
-// space and time constants
-int NX, NY; // global size
-int Nx, Ny; // local size
-int Nxm1, Nym1;
-int Nxp1, Nyp1;
-int NXp1, NYp1; // global size
 
 // variable for printing out intermediate initialisation info
 int print = 1;


### PR DESCRIPTION
I spotted another bug, namely I wasn't able to run the code on two procs (they wouldn't communicate properly and I saw a big discontinuity in the middle of the domain). It turned out to be due to a miscommunication when there are only two processors (as then the both of the processes that rank 0 would send to would be rank 1). The error resulted the northern value being received at the southern boundary and vice versa, and I could resolve it by switching the order of the receive commands in domain.h.

To counter the processor/grid mismatch I added the variable rank_crit, which holds the last rank that actually receives a part of the grid to manipulate with the standard FFTW decomposition. I had to modify three things because of this:
1) Only the ranks <= rank_crit take part in the communication process
2) The northern boundary condition is applied at rank_crit
3) Only the ranks <= rank_crit write their data in the output

Else I hope that that was it. 